### PR TITLE
Simplify macro code & Cosmetic

### DIFF
--- a/src/worker/wideint.h
+++ b/src/worker/wideint.h
@@ -6,7 +6,7 @@
 #define WIDEINT_WIDEINT_H_
 
 /* all GNU compilers */
-#ifdef __GNUC__
+#if defined(__GNUC__)
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpragmas"
@@ -43,6 +43,6 @@ static int __builtin_ctzx(uint128_t n)
 
 #else
 #	error "Unsupported compiler"
-#endif /* __GNUC__*/
+#endif /* defined(__GNUC__) */
 
 #endif /* WIDEINT_WIDEINT_H_ */

--- a/src/worker/wideint.h
+++ b/src/worker/wideint.h
@@ -43,6 +43,6 @@ static int __builtin_ctzx(uint128_t n)
 
 #else
 #	error "Unsupported compiler"
-#endif
+#endif /* __GNUC__*/
 
 #endif /* WIDEINT_WIDEINT_H_ */

--- a/src/worker/wideint.h
+++ b/src/worker/wideint.h
@@ -26,7 +26,7 @@ typedef __int128 int128_t;
 #pragma GCC diagnostic pop
 
 #define INT128_C(n) ( (int128_t)n )
-#define INT128_MAX ( ((INT128_C(1)<<(128-2))-1)*2+1 )
+#define INT128_MAX ( (int128_t)(UINT128_MAX >> 1) )
 #define INT128_MIN ( -INT128_MAX - 1 )
 
 #include <limits.h>


### PR DESCRIPTION
Cosmetic changes:

 - `#ifdef` is very similar to `#ifndef`.  Replace it by the clearer `#if defined()`
 - Add comment after `#endif` for very far `#ifdef`

Simplify macro code:

`INT128_MAX`:

INT128_MAX bits are: `0111 1111 1111 1111 ... 1111` that is a zero in the MSb and 127 ones in the LSbits

Given that UINT128_MAX is all ones, and unsigned right shift is very well defined, INT128_MAX is just UINT128_MAX shifted one place to the right, and then casted to the signed type.