### PR TITLE
make project work on mac m1/m2

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -9,8 +9,8 @@ export SERVER_NAME=pcbarina.fit.vutbr.cz
 echo "hostname=$(hostname)"
 echo "pwd=$(pwd)"
 echo "HOME=$HOME"
-echo "cpu model name=$(cat /proc/cpuinfo | grep "model name" | head -n1)"
-echo "cpus=$(cat /proc/cpuinfo | grep processor | wc -l)"
+echo "cpu model name=$(sysctl -a | grep machdep.cpu.brand_string)"
+echo "cpus=$(sysctl -a | grep machdep.cpu.thread_count | sed 's/^.*: //')"
 echo "TMPDIR=$TMPDIR"
 
 set -u
@@ -31,9 +31,9 @@ if type clang > /dev/null 2> /dev/null && clang --version | grep -qE "version (8
 fi
 
 # don't forget git clone git@github.com:xbarin02/collatz.git into $HOME
-SRCDIR=$HOME/collatz/
-MAPDIR=$HOME/collatz-sieve/
-TMP=$(mktemp -d collatz.XXXXXXXX --tmpdir)
+SRCDIR=$HOME/Documents/Projects/Collatz/collatz/
+MAPDIR=$HOME/Documents/Projects/Collatz/collatz-sieve/
+TMP=$(mktemp -d "${TMPDIR:-/tmp}"collatz.XXXXXXXX)
 
 echo "SRCDIR=$SRCDIR"
 echo "TMP=$TMP"
@@ -63,7 +63,7 @@ pushd -- "$TMP"
 
 cp -r "${SRCDIR}" .
 
-cd collatz/src
+cd src
 
 HOSTNAME=$(hostname -s | tr '[:upper:]' '[:lower:]')
 
@@ -74,16 +74,16 @@ fi
 
 # build mclient & worker
 make -C worker clean all USE_LIBGMP=1 CC=$CC USE_SIEVE=1 USE_PRECALC=1 SIEVE_LOGSIZE=34 USE_SIEVE3=0 USE_SIEVE9=1 USE_LUT50=1
-make -C gpuworker clean all CC=$CC TASK_UNITS=${TASK_UNITS} SIEVE_LOGSIZE=24 USE_SIEVE3=1 || echo "unable to build gpuworker"
+#make -C gpuworker clean all CC=$CC TASK_UNITS=${TASK_UNITS} SIEVE_LOGSIZE=24 USE_SIEVE3=1 || echo "unable to build gpuworker"
 make -C mclient clean all
 
 pushd "$MAPDIR"
-./unpack.sh esieve-34.lut50 "$TMP"/collatz/src/worker
-./unpack.sh esieve-24 "$TMP"/collatz/src/gpuworker
+./unpack.sh esieve-34.lut50 "$TMP"/src/worker
+#./unpack.sh esieve-24 "$TMP"/src/gpuworker
 popd
 
 cd mclient
 
-CLEANUP_DIR=$TMP screen -d -m ./spawn.sh $*
+export CLEANUP_DIR=$TMP && screen -d -m /opt/homebrew/bin/bash ./spawn.sh $*
 
 popd

--- a/src/gpuworker/Makefile
+++ b/src/gpuworker/Makefile
@@ -1,4 +1,4 @@
-CFLAGS+=-std=c89 -pedantic -Wall -Wextra -march=native -O3 -D_XOPEN_SOURCE=500 -DCL_TARGET_OPENCL_VERSION=220 -DCL_USE_DEPRECATED_OPENCL_1_2_APIS
+CFLAGS+=-std=gnu99 -pedantic -Wall -Wextra -Wno-long-long -march=native -O3 -D_XOPEN_SOURCE=500 -DCL_TARGET_OPENCL_VERSION=220 -DCL_USE_DEPRECATED_OPENCL_1_2_APIS
 LDFLAGS+=
 LDLIBS+=-lOpenCL
 BINS=gpuworker
@@ -21,8 +21,8 @@ endif
 CFLAGS+=-DTASK_UNITS=$(TASK_UNITS)
 
 ifeq ($(USE_LIBGMP), 1)
-	CFLAGS+=-D_USE_GMP
-	LDLIBS+=-lgmp
+	CFLAGS+=-I/opt/homebrew/include -D_USE_GMP
+	LDLIBS+=-L/opt/homebrew/lib -lgmp
 endif
 
 ifeq ($(USE_SIEVE3), 1)

--- a/src/gpuworker/gpuworker.c
+++ b/src/gpuworker/gpuworker.c
@@ -8,7 +8,7 @@
 #include <stdint.h>
 #include <inttypes.h>
 #include <string.h>
-#include <CL/cl.h>
+#include <OpenCL/cl.h>
 
 /* used by mmap */
 #include <sys/types.h>
@@ -719,9 +719,9 @@ int main(int argc, char *argv[])
 				alarm(seconds = atoul(optarg));
 				printf("ALARM %lu\n", seconds);
 				break;
-			case 'k':
-				kernel = strdup(optarg);
-				break;
+			//case 'k':
+			//	kernel = strdup(optarg);
+			//	break;
 			case '1':
 				g_ocl_ver1 = 1;
 				break;

--- a/src/mclient/Makefile
+++ b/src/mclient/Makefile
@@ -1,5 +1,5 @@
-CFLAGS+=-std=c89 -pedantic -Wall -Wextra -fopenmp -march=native -O3 -D_XOPEN_SOURCE -D_GNU_SOURCE
-LDFLAGS+=-fopenmp
+CFLAGS+=-std=c2x -Wall -Wextra -Wno-strict-prototypes -Xclang -fopenmp -march=native -O3 -D_XOPEN_SOURCE -D_GNU_SOURCE
+LDFLAGS+=-lomp
 LDLIBS+=
 BINS=mclient
 

--- a/src/mclient/spawn.sh
+++ b/src/mclient/spawn.sh
@@ -46,7 +46,7 @@ if ! (set -o noclobber ; echo > "${LOCKFILE}"); then
 fi
 
 # https://stackoverflow.com/questions/6481005/how-to-obtain-the-number-of-cpus-cores-in-linux-from-the-command-line
-THREADS=$(awk '{ if ($0~/^physical id/) { p=$NF }; if ($0~/^core id/) { cores[p$NF]=p$NF }; if ($0~/processor/) { cpu++ } } END { for (key in cores) { n++ } } END { if (n) {print n} else {print cpu} }' /proc/cpuinfo)
+THREADS=$(sysctl -a | grep machdep.cpu.thread_count | sed 's/^.*: //')
 # '
 CLIENT=./mclient
 

--- a/src/query/Makefile
+++ b/src/query/Makefile
@@ -1,5 +1,5 @@
-CFLAGS+=-std=c89 -pedantic -Wall -Wextra -fopenmp -march=native -O3 -D_XOPEN_SOURCE -D_POSIX_C_SOURCE=199309L
-LDFLAGS+=
+CFLAGS+=-std=gnu99 -pedantic -Wall -Wextra -Xclang -fopenmp -march=native -O3 -D_XOPEN_SOURCE -D_POSIX_C_SOURCE=199309L
+LDFLAGS+=-lomp
 LDLIBS+=
 BINS=query
 

--- a/src/server/Makefile
+++ b/src/server/Makefile
@@ -1,11 +1,11 @@
-CFLAGS+=-std=c89 -pedantic -Wall -Wextra -fopenmp -march=native -O3 -D_XOPEN_SOURCE -D_GNU_SOURCE
-LDFLAGS+=-fopenmp
+CFLAGS+=-std=c2x -pedantic -Wall -Wextra -Xclang -fopenmp -march=native -O3 -D_XOPEN_SOURCE -D_GNU_SOURCE
+LDFLAGS+=-lomp
 LDLIBS+=-lm
 BINS=server chk-tool verify-result find-maxima
 
 ifeq ($(USE_LIBGMP), 1)
-	CFLAGS+=-D_USE_GMP
-	LDLIBS+=-lgmp
+	CFLAGS+=-I/opt/homebrew/include -D_USE_GMP
+	LDLIBS+=-L/opt/homebrew/lib -lgmp
 endif
 
 ifeq ($(USE_LIBM), 1)

--- a/src/steps/Makefile
+++ b/src/steps/Makefile
@@ -1,11 +1,11 @@
-CFLAGS+=-std=c89 -pedantic -Wall -Wextra -march=native -O3 -D_XOPEN_SOURCE
+CFLAGS+=-std=c2x -pedantic -Wall -Wextra -Wno-long-long -march=native -O3 -D_XOPEN_SOURCE
 LDFLAGS=
 LDLIBS+=-lm
 BINS=steps max-steps max-value max-strength max-completeness max-residue show path
 
 ifeq ($(USE_LIBGMP), 1)
-	CFLAGS+=-D_USE_GMP
-	LDLIBS+=-lgmp
+	CFLAGS+=-I/opt/homebrew/include -D_USE_GMP
+	LDLIBS+=-L/opt/homebrew/lib -lgmp
 endif
 
 CFLAGS+=$(EXTRA_CFLAGS)

--- a/src/worker/Makefile
+++ b/src/worker/Makefile
@@ -1,11 +1,11 @@
-CFLAGS+=-std=c89 -pedantic -Wall -Wextra -march=native -O3 -D_XOPEN_SOURCE=500
-LDFLAGS=-Wl,--as-needed
+CFLAGS+=-std=c2x -v -pedantic -Wall -Wextra -Wno-long-long -march=native -O3 -D_XOPEN_SOURCE=500
+LDFLAGS=
 LDLIBS+=
 BINS=worker
 
 ifeq ($(USE_LIBGMP), 1)
-	CFLAGS+=-D_USE_GMP
-	LDLIBS+=-lgmp
+	CFLAGS+=-I/opt/homebrew/include -D_USE_GMP
+	LDLIBS+=-L/opt/homebrew/lib -lgmp
 endif
 
 ifeq ($(USE_SIEVE), 1)

--- a/src/worker/README
+++ b/src/worker/README
@@ -6,3 +6,29 @@ make CC=gcc
 or
 
 make CC=clang
+
+MAC OS (M1/M2 chip)
+=====
+
+git checkout macos-build
+./scripts/bootstrap.sh
+
+prerequisites:
+
+1. install bash 4+ from homebrew:
+
+brew install bash
+
+2. install openmp for Mac M1/M2
+
+https://mac.r-project.org/openmp/
+
+Links:
+
+https://apple.stackexchange.com/questions/352769/does-macos-have-a-command-to-retrieve-detailed-cpu-information-like-proc-cpuinf
+https://stackoverflow.com/questions/26284110/strdup-confused-about-warnings-implicit-declaration-makes-pointer-with
+https://stackoverflow.com/questions/56512690/how-to-get-bashpid-in-bash-version-3
+https://apple.stackexchange.com/questions/193411/update-bash-to-version-4-0-on-osx
+https://github.com/Homebrew/homebrew-core/issues/106393
+
+I was not able to compile gpuworker, which is probably to be expected for non-NVIDIA chip


### PR DESCRIPTION
This allowed me to run mclient, worker and optionally server locally on Mac M1 Pro.
GPU worker does not work on Mac M1, but I gues this is to be expected.

On Mac M1 Pro it takes around 4.5 minutes per core to process single task with 10 cores available.
M2 Ultra performance should be somewhere beween 20% - 50% better per core with up to 76 cores.